### PR TITLE
fix: use silver upcoming instead of silver

### DIFF
--- a/pkg/opslevel/opslevel.go
+++ b/pkg/opslevel/opslevel.go
@@ -14,6 +14,35 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Initializes constants for OpsLevel level and lifecycle indexes.
+const (
+	// BeginnerLevel is the index for the Beginner level in OpsLevel.
+	BeginnerLevel = 0
+	// BronzeLevel is the index for Bronze level in  OpsLevel.
+	BronzeLevel = 1
+	// SilverLevel is the index for Silver level in  OpsLevel.
+	SilverLevel = 2
+	// SilverUpcomingLevel is the index for the Silver (Upcoming) level in OpsLevel.
+	SilverUpcomingLevel = 3
+	// GoldLevel is the index for Gold level in  OpsLevel.
+	GoldLevel = 4
+	// PlatinumLevel is the index for Platinum level in  OpsLevel.
+	PlatinumLevel = 5
+
+	// DevelopmentLifecycle if the index for the Development lifecycle in OpsLevel.
+	DevelopmentLifecycle = 1
+	// PrivateBetaLifecycle if the index for the Private Beta lifecycle in OpsLevel.
+	PrivateBetaLifecycle = 2
+	// PublicBetaLifecycle if the index for the Public Beta lifecycle in OpsLevel.
+	PublicBetaLifecycle = 3
+	// PublicLifecycle if the index for the Public lifecycle in OpsLevel.
+	PublicLifecycle = 4
+	// OpsLifecycle if the index for the Ops lifecycle in OpsLevel.
+	OpsLifecycle = 5
+	// EndOfLifeLifecycle if the index for the Endo-of-Life lifecycle in OpsLevel.
+	EndOfLifeLifecycle = 6
+)
+
 // NewClient returns a new opslevel client configured with the token we expect to exist in
 // the environment.
 func NewClient() (*opslevel.Client, error) {
@@ -25,20 +54,14 @@ func NewClient() (*opslevel.Client, error) {
 }
 
 // LifecycleToLevel maps lifecycle index to level index.
-// We want to keep this at the index level in case names or other attributes change
+// We want to keep this at the index level in case names or other attributes change.
 var LifecycleToLevel = map[int]int{
-	// In Development >= Beginner
-	1: 0,
-	// Private Beta >= Silver (Upcoming)
-	2: 3,
-	// Public Beta >= Silver (Upcoming)
-	3: 3,
-	// Public/GA >= Silver (Upcoming)
-	4: 3,
-	// Ops >= Silver (Upcoming)
-	5: 3,
-	// End-of-life >= Beginner
-	6: 0,
+	DevelopmentLifecycle: BeginnerLevel,
+	PrivateBetaLifecycle: SilverUpcomingLevel,
+	PublicBetaLifecycle:  SilverUpcomingLevel,
+	PublicLifecycle:      SilverUpcomingLevel,
+	OpsLifecycle:         SilverUpcomingLevel,
+	EndOfLifeLifecycle:   BeginnerLevel,
 }
 
 // GetServiceAlias safely retrieves the first alias for the provided service.

--- a/pkg/opslevel/opslevel.go
+++ b/pkg/opslevel/opslevel.go
@@ -29,14 +29,14 @@ func NewClient() (*opslevel.Client, error) {
 var LifecycleToLevel = map[int]int{
 	// In Development >= Beginner
 	1: 0,
-	// Private Beta >= Silver
-	2: 2,
-	// Public Beta >= Silver
-	3: 2,
-	// Public/GA >= Silver
-	4: 2,
-	// Ops >= Silver
-	5: 2,
+	// Private Beta >= Silver (Upcoming)
+	2: 3,
+	// Public Beta >= Silver (Upcoming)
+	3: 3,
+	// Public/GA >= Silver (Upcoming)
+	4: 3,
+	// Ops >= Silver (Upcoming)
+	5: 3,
 	// End-of-life >= Beginner
 	6: 0,
 }

--- a/pkg/opslevel/opslevel_test.go
+++ b/pkg/opslevel/opslevel_test.go
@@ -83,13 +83,13 @@ func TestIsComplient(t *testing.T) {
 			name: "level matches expected level",
 			service: opslevelGo.Service{
 				Lifecycle: opslevelGo.Lifecycle{
-					Index: 4,
+					Index: opslevel.PublicLifecycle,
 				},
 			},
 			sm: &opslevelGo.ServiceMaturity{
 				MaturityReport: opslevelGo.MaturityReport{
 					OverallLevel: opslevelGo.Level{
-						Index: 3,
+						Index: opslevel.SilverUpcomingLevel,
 					},
 				},
 			},
@@ -100,13 +100,13 @@ func TestIsComplient(t *testing.T) {
 			name: "level below expected level",
 			service: opslevelGo.Service{
 				Lifecycle: opslevelGo.Lifecycle{
-					Index: 4,
+					Index: opslevel.PublicLifecycle,
 				},
 			},
 			sm: &opslevelGo.ServiceMaturity{
 				MaturityReport: opslevelGo.MaturityReport{
 					OverallLevel: opslevelGo.Level{
-						Index: 1,
+						Index: opslevel.BronzeLevel,
 					},
 				},
 			},
@@ -117,13 +117,13 @@ func TestIsComplient(t *testing.T) {
 			name: "level above expected level",
 			service: opslevelGo.Service{
 				Lifecycle: opslevelGo.Lifecycle{
-					Index: 4,
+					Index: opslevel.PublicLifecycle,
 				},
 			},
 			sm: &opslevelGo.ServiceMaturity{
 				MaturityReport: opslevelGo.MaturityReport{
 					OverallLevel: opslevelGo.Level{
-						Index: 4,
+						Index: opslevel.GoldLevel,
 					},
 				},
 			},
@@ -140,7 +140,7 @@ func TestIsComplient(t *testing.T) {
 			sm: &opslevelGo.ServiceMaturity{
 				MaturityReport: opslevelGo.MaturityReport{
 					OverallLevel: opslevelGo.Level{
-						Index: 3,
+						Index: opslevel.SilverUpcomingLevel,
 					},
 				},
 			},
@@ -172,15 +172,15 @@ func TestIsComplient(t *testing.T) {
 func TestGetExpectedLevel(t *testing.T) {
 	levels := []opslevelGo.Level{
 		{
-			Index: 0,
+			Index: opslevel.BeginnerLevel,
 			Name:  "Beginner",
 		},
 		{
-			Index: 3,
+			Index: opslevel.SilverUpcomingLevel,
 			Name:  "Silver (Upcoming)",
 		},
 		{
-			Index: 1,
+			Index: opslevel.BronzeLevel,
 			Name:  "Bronze",
 		},
 	}
@@ -194,7 +194,7 @@ func TestGetExpectedLevel(t *testing.T) {
 			name: "level matching index",
 			service: opslevelGo.Service{
 				Lifecycle: opslevelGo.Lifecycle{
-					Index: 0,
+					Index: opslevel.DevelopmentLifecycle,
 				},
 			},
 			expected:  "Beginner",
@@ -204,7 +204,7 @@ func TestGetExpectedLevel(t *testing.T) {
 			name: "level not matching index",
 			service: opslevelGo.Service{
 				Lifecycle: opslevelGo.Lifecycle{
-					Index: 2,
+					Index: opslevel.PrivateBetaLifecycle,
 				},
 			},
 			expected:  "Silver (Upcoming)",

--- a/pkg/opslevel/opslevel_test.go
+++ b/pkg/opslevel/opslevel_test.go
@@ -89,7 +89,7 @@ func TestIsComplient(t *testing.T) {
 			sm: &opslevelGo.ServiceMaturity{
 				MaturityReport: opslevelGo.MaturityReport{
 					OverallLevel: opslevelGo.Level{
-						Index: 2,
+						Index: 3,
 					},
 				},
 			},
@@ -123,7 +123,7 @@ func TestIsComplient(t *testing.T) {
 			sm: &opslevelGo.ServiceMaturity{
 				MaturityReport: opslevelGo.MaturityReport{
 					OverallLevel: opslevelGo.Level{
-						Index: 3,
+						Index: 4,
 					},
 				},
 			},
@@ -176,8 +176,8 @@ func TestGetExpectedLevel(t *testing.T) {
 			Name:  "Beginner",
 		},
 		{
-			Index: 2,
-			Name:  "Silver",
+			Index: 3,
+			Name:  "Silver (Upcoming)",
 		},
 		{
 			Index: 1,
@@ -207,7 +207,7 @@ func TestGetExpectedLevel(t *testing.T) {
 					Index: 2,
 				},
 			},
-			expected:  "Silver",
+			expected:  "Silver (Upcoming)",
 			expectErr: false,
 		},
 		{
@@ -229,7 +229,7 @@ func TestGetExpectedLevel(t *testing.T) {
 				if tc.expectErr {
 					return
 				}
-				t.Fatalf("unexpected error")
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if tc.expectErr {
 				t.Fatalf("expected and error but did not receive one")


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

I realized we never switched to silver upcoming. This changes the levels correctly. 

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-1238]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-1238]: https://outreach-io.atlassian.net/browse/DT-1238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ