### PR TITLE
fix(opslevel): ensure we handle indexes starting at 1

### DIFF
--- a/actions/opslevel/main.go
+++ b/actions/opslevel/main.go
@@ -140,7 +140,7 @@ func RunAction(ctx context.Context, _ *github.Client, _ *actions.GitHubContext,
 	return nil
 }
 
-// buildSlackMessage builds a slack message for all non complient service that the provided team owns.
+// buildSlackMessage builds a slack message for all non compliant service that the provided team owns.
 func buildSlackMessage(client *opslevelGo.Client, team *opslevelGo.Team,
 	levels []opslevelGo.Level, t *template.Template) (string, error) {
 	services, err := client.ListServicesWithOwner(team.Alias)
@@ -166,11 +166,11 @@ func buildSlackMessage(client *opslevelGo.Client, team *opslevelGo.Team,
 
 		isCompliant, err := opslevel.IsCompliant(service, sm)
 		if err != nil {
-			actions.Errorf("is complient for %s: %v", service.Name, err.Error())
+			actions.Errorf("is compliant for %s: %v", service.Name, err.Error())
 			continue
 		}
 
-		// If the service is complient, we skip adding to the slack message.
+		// If the service is compliant, we skip adding to the slack message.
 		if isCompliant {
 			continue
 		}

--- a/pkg/opslevel/opslevel.go
+++ b/pkg/opslevel/opslevel.go
@@ -88,7 +88,7 @@ func IsCompliant(service *opslevel.Service, sm *opslevel.ServiceMaturity) (bool,
 
 // GetExpectedLevel retrieves the expected maturity level of the service
 func GetExpectedLevel(service *opslevel.Service, levels []opslevel.Level) (string, error) {
-	if len(LifecycleToLevel) <= service.Lifecycle.Index {
+	if len(LifecycleToLevel) < service.Lifecycle.Index {
 		return "", fmt.Errorf("unsupported lifecycle %d %s",
 			service.Lifecycle.Index, service.Lifecycle.Name)
 	}
@@ -118,7 +118,7 @@ func GetSlackChannel(team *opslevel.Team) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("No slach channel found for team")
+	return "", fmt.Errorf("no slack channel found for team")
 }
 
 // GetMaturityReportURL retrieves the html url for the maturity report

--- a/pkg/opslevel/opslevel.go
+++ b/pkg/opslevel/opslevel.go
@@ -77,7 +77,7 @@ func GetServiceAlias(service *opslevel.Service) (string, error) {
 // This check is primarily controlled by the LifecycleToLevel map
 func IsCompliant(service *opslevel.Service, sm *opslevel.ServiceMaturity) (bool, error) {
 	currentLevelIndex := sm.MaturityReport.OverallLevel.Index
-	if len(LifecycleToLevel) <= service.Lifecycle.Index {
+	if len(LifecycleToLevel) < service.Lifecycle.Index {
 		return false, fmt.Errorf("unsupported lifecycle %d %s",
 			service.Lifecycle.Index, service.Lifecycle.Name)
 	}

--- a/pkg/opslevel/opslevel_test.go
+++ b/pkg/opslevel/opslevel_test.go
@@ -58,7 +58,7 @@ func TestGetServiceAlias(t *testing.T) {
 				if tc.expectErr {
 					return
 				}
-				t.Fatalf("unexpected error")
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if tc.expectErr {
 				t.Fatalf("expected and error but did not receive one")
@@ -156,7 +156,7 @@ func TestIsComplient(t *testing.T) {
 				if tc.expectErr {
 					return
 				}
-				t.Fatalf("unexpected error")
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if tc.expectErr {
 				t.Fatalf("expected and error but did not receive one")
@@ -219,6 +219,16 @@ func TestGetExpectedLevel(t *testing.T) {
 			},
 			expected:  "",
 			expectErr: true,
+		},
+		{
+			name: "gets last level with indexes starting at 1",
+			service: opslevelGo.Service{
+				Lifecycle: opslevelGo.Lifecycle{
+					Index: opslevel.EndOfLifeLifecycle,
+				},
+			},
+			expected:  "Beginner",
+			expectErr: false,
 		},
 	}
 
@@ -335,7 +345,7 @@ func TestGetSlackChannel(t *testing.T) {
 				if tc.expectErr {
 					return
 				}
-				t.Fatalf("unexpected error")
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if tc.expectErr {
 				t.Fatalf("expected and error but did not receive one")

--- a/pkg/opslevel/opslevel_test.go
+++ b/pkg/opslevel/opslevel_test.go
@@ -71,7 +71,7 @@ func TestGetServiceAlias(t *testing.T) {
 	}
 }
 
-func TestIsComplient(t *testing.T) {
+func TestIsCompliant(t *testing.T) {
 	testCases := []struct {
 		name      string
 		service   opslevelGo.Service


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Since the OpsLevel lifecycle index starts at 1, we have to check the slice length one greater than what we normally would.

During the last run, we got the following errors:

```
Error: is compliant for contact-extractor: unsupported lifecycle 6 End-of-life
Error: is compliant for arborist: unsupported lifecycle 6 End-of-life
```

These did not result in a real error because we allow any level for End-of-life. But if things change in the future, we want to make sure that we check all the levels.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
