### PR TITLE
fix(deploy): copy the correct lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /src
 # Copy our source code, go module information, and the files necessary
 # to run make comands into the builder directory.
 COPY actions/${ACTION}/ ./cmd/action/
-COPY go.mod go.sum Makefile bootstrap.lock ./
+COPY go.mod go.sum Makefile stencil.lock ./
 COPY scripts/ ./scripts/
 COPY pkg/ ./pkg/
 


### PR DESCRIPTION
## What this PR does / why we need it

Found an obsolete reference to `bootstrap` when auditing a failed CI job. I believe the copying of the job is necessary for using the `Makefile` (that is how it determines which version of `devbase` to download).