### PR TITLE
fix: re-add OUTREACH_DOCKER_JSON to actions, but as a non-required secret

### DIFF
--- a/.github/workflows/brokenbranch.yaml
+++ b/.github/workflows/brokenbranch.yaml
@@ -3,6 +3,8 @@ name: brokenbranch
 on:
   workflow_call:
     secrets:
+      OUTREACH_DOCKER_JSON:
+        required: false
       PAT_OUTREACH_CI:
         required: false
       SLACK_TOKEN:

--- a/.github/workflows/commitguard.yaml
+++ b/.github/workflows/commitguard.yaml
@@ -3,6 +3,8 @@ name: commitguard
 on:
   workflow_call:
     secrets:
+      OUTREACH_DOCKER_JSON:
+        required: false
       PAT_OUTREACH_CI:
         required: false
     inputs:

--- a/.github/workflows/conventional_commit.yaml
+++ b/.github/workflows/conventional_commit.yaml
@@ -3,6 +3,8 @@ name: contentional_commit
 on:
   workflow_call:
     secrets:
+      OUTREACH_DOCKER_JSON:
+        required: false
       PAT_OUTREACH_CI:
         required: false
     inputs:

--- a/.github/workflows/pull_request-shared-actions.yaml
+++ b/.github/workflows/pull_request-shared-actions.yaml
@@ -7,5 +7,3 @@ jobs:
   conventional_commit:
     name: Conventional Commit
     uses: getoutreach/actions/.github/workflows/conventional_commit.yaml@main
-    secrets:
-      OUTREACH_DOCKER_JSON: ${{ secrets.OUTREACH_DOCKER_JSON }}


### PR DESCRIPTION
## What this PR does / why we need it

Evidently specifying a secret that isn't explicitly specified in the action is not allowed, so we're re-adding the `OUTREACH_DOCKER_JSON` variable (except no longer required) until everyone fixes their services.